### PR TITLE
Bump v0.1.6 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "host-namespaces-psp"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-namespaces-psp"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Rafael Fernández López <ereslibre@ereslibre.es>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,29 +4,29 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.5
+version: 0.1.6
 name: host-namespaces-psp
 displayName: Host Namespaces PSP
-createdAt: 2023-03-21T11:52:21.551969227Z
+createdAt: 2023-07-07T16:30:27.543864099Z
 description: A Kubewarden policy that controls the usage of host namespaces
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/host-namespaces-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/host-namespaces-psp:v0.1.5
+  image: ghcr.io/kubewarden/policies/host-namespaces-psp:v0.1.6
 keywords:
 - psp
 - container
 - network
 links:
 - name: policy
-  url: https://github.com/kubewarden/host-namespaces-psp-policy/releases/download/v0.1.5/policy.wasm
+  url: https://github.com/kubewarden/host-namespaces-psp-policy/releases/download/v0.1.6/policy.wasm
 - name: source
   url: https://github.com/kubewarden/host-namespaces-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/host-namespaces-psp:v0.1.5
+  kwctl pull ghcr.io/kubewarden/policies/host-namespaces-psp:v0.1.6
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Updates the Cargo and artifacthub files bumping the policy version to v0.1.6

Related to https://github.com/kubewarden/kubewarden-controller/issues/479