### PR TITLE
docs: Migration notice on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+[!IMPORTANT]
+**Notice:**
+Starting from Kubewarden release 1.32.0, all code from this repository has been merged into [github.com/kubewarden/policies](https://github.com/kubewarden/policies), which is now a monorepo containing policies.
+Please refer to that repository for future updates and development.
+**This repository is now archived. Development continues in the new location.**
+
+
 [![Kubewarden Policy Repository](https://github.com/kubewarden/community/blob/main/badges/kubewarden-policies.svg)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#policy-scope)
 [![Stable](https://img.shields.io/badge/status-stable-brightgreen?style=for-the-badge)](https://github.com/kubewarden/community/blob/main/REPOSITORIES.md#stable)
 


### PR DESCRIPTION
# Description

docs: Migration notice on README.md

Adds migration notice to README.md about monorepo and archive status.
